### PR TITLE
Permet la suppression des requêtes

### DIFF
--- a/src/containers/Activite/Request/RequestActivity.tsx
+++ b/src/containers/Activite/Request/RequestActivity.tsx
@@ -5,11 +5,13 @@ import type RequestType from "@/enums/RequestType"
 import useUpdateAnimeStorageStateLight from "@/hooks/components/useUpdateAnimeStorageStateLight"
 import useRequest from "@/hooks/containers/Activite/Request/useRequest"
 import useLibrary from "@/hooks/containers/AnimeLibrary/useLibrary"
+import useUserContext from "@/hooks/context/useUserContext"
 import usePagination from "@/hooks/usePagination"
 import { AnimeDTO } from "@/interfaces/services/AnimeService/AnimeDTO"
 import type RequestDTO from "@/interfaces/services/RequestService/RequestDTO"
 import { formatJavaLocalDateTimeArray } from "@/utils/dateUtils"
 import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder"
+import DeleteIcon from "@mui/icons-material/Delete"
 import DriveFileMoveIcon from "@mui/icons-material/DriveFileMove"
 import PendingIcon from "@mui/icons-material/Pending"
 import ThumbDownIcon from "@mui/icons-material/ThumbDown"
@@ -29,11 +31,12 @@ import { useCallback } from "react"
 import { NavLink } from "react-router"
 
 const RequestActivity = () => {
-  const { requests, updateRequest } = useRequest()
+  const { requests, updateRequest, deleteRequest } = useRequest()
   const { rowsPerPage, page, handleChangePage, handleChangeRowsPerPage, labelTemplate, sliceBegin, sliceEnd } =
     usePagination<RequestDTO>(requests ?? [])
   const { animes } = useLibrary()
   const { updateAnime } = useUpdateAnimeStorageStateLight()
+  const { user, isAdmin } = useUserContext()
 
   const renderRequestState = useCallback(
     (requestStatus: RequestStatus) =>
@@ -97,6 +100,20 @@ const RequestActivity = () => {
     { minLevel: "admin" }
   )
 
+  const userActions = withAuthorization(
+    ({ request }: { request: RequestDTO }) =>
+      isAdmin || request.creator === user?.name ? (
+        <IconButton
+          color="error"
+          onClick={() => {
+            deleteRequest(request.id)
+          }}>
+          <DeleteIcon />
+        </IconButton>
+      ) : undefined,
+    { minLevel: "user" }
+  )
+
   const requestRender = useCallback(
     (request: RequestDTO) => {
       const animeInServer = animes.find(({ malId }) => request.malId === malId)
@@ -123,6 +140,7 @@ const RequestActivity = () => {
           <TableCell>{request.assignedUser} </TableCell>
           <TableCell>
             {request.state === RequestStatus.PENDING ? adminActions({ request, animeInServer }) : undefined}
+            {userActions({ request })}
           </TableCell>
         </TableRow>
       )
@@ -145,7 +163,7 @@ const RequestActivity = () => {
             <TableCell> Actions </TableCell>
           </TableRow>
         </TableHead>
-        <TableBody>{requests.slice(sliceBegin, sliceEnd).map(requestRender)}</TableBody>
+        <TableBody>{requests.toReversed().slice(sliceBegin, sliceEnd).map(requestRender)}</TableBody>
       </Table>
       <TablePagination
         rowsPerPageOptions={[5, 10, 25]}

--- a/src/hooks/containers/Activite/Request/useRequest.ts
+++ b/src/hooks/containers/Activite/Request/useRequest.ts
@@ -1,13 +1,17 @@
 import useAppContext from "@/hooks/context/useAppContext"
+import useUserContext from "@/hooks/context/useUserContext"
 import type RequestDTO from "@/interfaces/services/RequestService/RequestDTO"
 import type ResponseError from "@/interfaces/services/ResponseError"
 import RequestService from "@/services/RequestService"
 import { useMutation, useQuery } from "@tanstack/react-query"
-import { useCallback, useEffect, useState } from "react"
+import { useSnackbar } from "notistack"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 const useRequest = () => {
-  const { setMyRequests } = useAppContext()
+  const { myRequests, setMyRequests } = useAppContext()
   const [requests, setRequests] = useState<RequestDTO[]>([])
+  const { enqueueSnackbar } = useSnackbar()
+  const { isAdmin } = useUserContext()
 
   const { data, isFetching: isAllRequestFetching } = useQuery({
     staleTime: 3600000,
@@ -36,6 +40,10 @@ const useRequest = () => {
   )
 
   const onErrorCreateRequest = useCallback((error: ResponseError, requestInput: RequestDTO) => {
+    enqueueSnackbar({
+      message: "Une erreur est survenue lors de la mise à jour d'une request",
+      variant: "error"
+    })
     console.error(
       "Une erreur est survenue lors de la mise à jour d'une request pour l'anime %s avec le status %s",
       requestInput.malId,
@@ -49,7 +57,42 @@ const useRequest = () => {
     onError: onErrorCreateRequest
   })
 
-  return { requests, isAllRequestFetching, updateRequest }
+  const deleteRequestCall = useCallback(async (id: number) => await RequestService.delete(id), [])
+
+  const onSuccessDeleteRequest = useCallback(
+    (__: void, id: number) => {
+      setRequests(requests => requests.filter(request => request.id !== id))
+      setMyRequests(requests => requests.filter(request => request.id !== id))
+    },
+    [setRequests, setMyRequests]
+  )
+
+  const onErrorDeleteRequest = useCallback((error: ResponseError, id: number) => {
+    const errorMessage =
+      error.response?.status === 412
+        ? "Vous n'avez pas la permission de supprimer cette request"
+        : "Une erreur est survenue lors de la suppression d'une request"
+
+    enqueueSnackbar({
+      message: errorMessage,
+      variant: "error"
+    })
+    console.error(
+      "Une erreur est survenue lors de la suppression de la request avec l'id %s et le status %s",
+      id,
+      error.response?.status
+    )
+  }, [])
+
+  const { mutate: deleteRequest } = useMutation({
+    mutationFn: deleteRequestCall,
+    onSuccess: onSuccessDeleteRequest,
+    onError: onErrorDeleteRequest
+  })
+
+  const displayedRequests = useMemo(() => (isAdmin ? requests : myRequests), [isAdmin, myRequests, requests])
+
+  return { requests: displayedRequests, isAllRequestFetching, updateRequest, deleteRequest }
 }
 
 export default useRequest

--- a/src/services/RequestService.ts
+++ b/src/services/RequestService.ts
@@ -1,7 +1,7 @@
 import type RequestDTO from "@/interfaces/services/RequestService/RequestDTO"
 import type RequestInputDTO from "@/interfaces/services/RequestService/RequestInputDTO"
 import api from "./api"
-import { get, post } from "./request/request"
+import { deleteRequest, get, post } from "./request/request"
 
 const RequestService = {
   create: async (requestInput: RequestInputDTO) =>
@@ -10,7 +10,8 @@ const RequestService = {
   getAssigned: async () => await get<RequestDTO[]>(api.request.getAssigned),
   getAll: async () => await get<RequestDTO[]>(api.request.getAll),
   update: async (requestInput: RequestInputDTO & Pick<Required<RequestInputDTO>, "id">) =>
-    await post<RequestInputDTO, RequestDTO>(api.request.update(requestInput.id), requestInput)
+    await post<RequestInputDTO, RequestDTO>(api.request.update(requestInput.id), requestInput),
+  delete: async (requestId: number) => await deleteRequest(api.request.delete(requestId))
 }
 
 export default RequestService

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -62,7 +62,8 @@ const api = {
     getMe: `${API_BASE_URL}/request/me`,
     getAssigned: `${API_BASE_URL}/request/assigned`,
     getAll: `${API_BASE_URL}/request/all`,
-    update: (requestId: number) => `${API_BASE_URL}/request/${requestId}`
+    update: (requestId: number) => `${API_BASE_URL}/request/${requestId}`,
+    delete: (requestId: number) => `${API_BASE_URL}/request/${requestId}`
   },
   seasons: {
     getSeasonsList: `${API_BASE_URL}/seasons`,


### PR DESCRIPTION
Permet aux utilisateurs de supprimer leurs propres requêtes et aux administrateurs de supprimer toutes les requêtes.

Cette modification introduit la possibilité de supprimer des requêtes via l'interface utilisateur. Seuls les administrateurs et les créateurs de la requête peuvent effectuer cette action.

- Ajoute une icône de suppression aux requêtes affichées.
- Implémente une fonction `deleteRequest` dans le hook `useRequest` pour gérer la suppression des requêtes.
- Affiche un message d'erreur si l'utilisateur n'a pas la permission de supprimer une requête.