### PR TITLE
feature/159 - Génère les URL MyAnimeList pour les animes

### DIFF
--- a/src/hooks/containers/Activite/MyAnimeList/useMyAnimeListMapper.ts
+++ b/src/hooks/containers/Activite/MyAnimeList/useMyAnimeListMapper.ts
@@ -11,7 +11,7 @@ const useMyAnimeListMapper = () => {
       const returnedAnime = {
         ...malAnime,
         malId: malAnime.id,
-        malUrl: "",
+        malUrl: `https://myanimelist.net/anime/${malAnime.id}`,
         malImg: malAnime.main_picture.medium,
         type: malAnime.media_type as AnimeType,
         episodes: malAnime.num_episodes,


### PR DESCRIPTION
Ajoute la logique de génération des URL complètes de MyAnimeList pour chaque anime. Auparavant, la propriété `malUrl` était une chaîne vide.

Cette modification permet désormais de créer des liens directs vers les pages détaillées des animes sur MyAnimeList. L'objectif est d'enrichir l'expérience utilisateur en facilitant l'accès aux informations complémentaires, notamment depuis les images des animes sur la page de saison.

Relatif à #159